### PR TITLE
Make #to_fs the default replacement for #to_s(:format)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Make #to_fs the default replacement for #to_s(:format).
+
 ## 0.1.0
 
 ### Added

--- a/lib/rubocop/cop/rails_deprecation/to_formatted_s.rb
+++ b/lib/rubocop/cop/rails_deprecation/to_formatted_s.rb
@@ -6,12 +6,15 @@ module RuboCop
       # This cop identifies passing a format to `#to_s`.
       #
       # @safety
-      #   This cop's auto-correction is unsafe because a custom or unrelated `to_s` method call would be change to `to_formatted_s`.
+      #   This cop's auto-correction is unsafe because a custom or unrelated `to_s` method call would be change to `to_fs`.
       #
       # @example
       #
       #   # bad
       #   to_s(:delimited)
+      #
+      #   # good
+      #   to_fs(:delimited)
       #
       #   # good
       #   to_formatted_s(:delimited)
@@ -24,7 +27,7 @@ module RuboCop
 
         self.minimum_target_rails_version = 7.0
 
-        MSG = 'Use `to_formatted_s(...)` instead of `to_s(...)`.'
+        MSG = 'Use `to_fs(...)` instead of `to_s(...)`.'
 
         def_node_matcher :to_s_with_any_argument?, <<~PATTERN
           (send _ :to_s _ ...)
@@ -36,7 +39,7 @@ module RuboCop
           add_offense(node) do |rewriter|
             rewriter.replace(
               node.loc.selector,
-              'to_formatted_s'
+              'to_fs'
             )
           end
         end

--- a/spec/rubocop/cop/rails_deprecation/to_formatted_s_spec.rb
+++ b/spec/rubocop/cop/rails_deprecation/to_formatted_s_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe RuboCop::Cop::RailsDeprecation::ToFormattedS, :config do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         to_s(:delimited)
-        ^^^^^^^^^^^^^^^^ Use `to_formatted_s(...)` instead of `to_s(...)`.
+        ^^^^^^^^^^^^^^^^ Use `to_fs(...)` instead of `to_s(...)`.
       RUBY
 
       expect_correction(<<~RUBY)
-        to_formatted_s(:delimited)
+        to_fs(:delimited)
       RUBY
     end
   end
@@ -58,11 +58,11 @@ RSpec.describe RuboCop::Cop::RailsDeprecation::ToFormattedS, :config do
     it 'registers an offense' do
       expect_offense(<<~RUBY)
         1.to_s(:delimited)
-        ^^^^^^^^^^^^^^^^^^ Use `to_formatted_s(...)` instead of `to_s(...)`.
+        ^^^^^^^^^^^^^^^^^^ Use `to_fs(...)` instead of `to_s(...)`.
       RUBY
 
       expect_correction(<<~RUBY)
-        1.to_formatted_s(:delimited)
+        1.to_fs(:delimited)
       RUBY
     end
   end


### PR DESCRIPTION
See also: https://github.com/rails/rails/pull/44354
