### PR TITLE
Rename Deprecation/ToFormattedS with RailsDeprecation/ToFormattedS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Rename Deprecation/ToFormattedS with RailsDeprecation/ToFormattedS.
+
 ## 0.4.0 - 2022-03-14
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-rails_deprecation (0.4.0)
-      rubocop
+      rubocop (>= 1.27)
 
 GEM
   remote: https://rubygems.org/
@@ -29,13 +29,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    rubocop (1.25.1)
+    rubocop (1.27.0)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.15.1, < 2.0)
+      rubocop-ast (>= 1.16.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.16.0)

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,4 +1,4 @@
-Deprecation/ToFormattedS:
+RailsDeprecation/ToFormattedS:
   Description: Use `to_fs(...)` instead of `to_s(...)`.
   Enabled: true
   VersionAdded: '0.1'

--- a/lib/rubocop-rails_deprecation.rb
+++ b/lib/rubocop-rails_deprecation.rb
@@ -6,6 +6,6 @@ require_relative 'rubocop/rails_deprecation'
 require_relative 'rubocop/rails_deprecation/version'
 require_relative 'rubocop/rails_deprecation/inject'
 
-RuboCop::Deprecation::Inject.defaults!
+RuboCop::RailsDeprecation::Inject.defaults!
 
 require_relative 'rubocop/cop/rails_deprecation_cops'

--- a/lib/rubocop/cop/rails_deprecation/base.rb
+++ b/lib/rubocop/cop/rails_deprecation/base.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    module Deprecation
+    module RailsDeprecation
       class Base < ::RuboCop::Cop::Base
         DEFAULT_MINIMUM_TARGET_RAILS_VERSION = 5.0
 

--- a/lib/rubocop/cop/rails_deprecation/to_formatted_s.rb
+++ b/lib/rubocop/cop/rails_deprecation/to_formatted_s.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    module Deprecation
+    module RailsDeprecation
       # This cop identifies passing a format to `#to_s`.
       #
       # @safety

--- a/lib/rubocop/rails_deprecation.rb
+++ b/lib/rubocop/rails_deprecation.rb
@@ -3,7 +3,7 @@
 require_relative 'rails_deprecation/version'
 
 module RuboCop
-  module Deprecation
+  module RailsDeprecation
     class Error < StandardError; end
     # Your code goes here...
     PROJECT_ROOT   = Pathname.new(__dir__).parent.parent.expand_path.freeze

--- a/lib/rubocop/rails_deprecation/inject.rb
+++ b/lib/rubocop/rails_deprecation/inject.rb
@@ -3,7 +3,7 @@
 # The original code is from https://github.com/rubocop/rubocop-rspec/blob/main/lib/rubocop/rspec/inject.rb
 # See https://github.com/rubocop/rubocop-rspec/blob/main/MIT-LICENSE.md
 module RuboCop
-  module Deprecation
+  module RailsDeprecation
     # Because RuboCop doesn't yet support plugins, we have to monkey patch in a
     # bit of our configuration.
     module Inject

--- a/lib/rubocop/rails_deprecation/version.rb
+++ b/lib/rubocop/rails_deprecation/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module RuboCop
-  module Deprecation
+  module RailsDeprecation
     VERSION = '0.4.0'
   end
 end

--- a/rubocop-rails_deprecation.gemspec
+++ b/rubocop-rails_deprecation.gemspec
@@ -4,7 +4,7 @@ require_relative 'lib/rubocop/rails_deprecation/version'
 
 Gem::Specification.new do |spec|
   spec.name = 'rubocop-rails_deprecation'
-  spec.version = RuboCop::Deprecation::VERSION
+  spec.version = RuboCop::RailsDeprecation::VERSION
   spec.authors = ['Ryo Nakamura']
   spec.email = ['r7kamura@gmail.com']
 
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop'
+  spec.add_runtime_dependency 'rubocop', '>= 1.27'
 end

--- a/spec/rubocop/cop/rails_deprecation/to_formatted_s_spec.rb
+++ b/spec/rubocop/cop/rails_deprecation/to_formatted_s_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Deprecation::ToFormattedS, :config do
+RSpec.describe RuboCop::Cop::RailsDeprecation::ToFormattedS, :config do
   let(:config) do
     RuboCop::Config.new(
       'AllCops' => {


### PR DESCRIPTION
https://github.com/rubocop/rubocop/pull/10452 was merged at rubocop 1.27.0.
